### PR TITLE
Add songs by name with youtube-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "discord.js" : "11.0.0",
     "ytdl-core" :  "github:fent/node-ytdl-core#master",
-    "node-opus" : "^0.2.1"
+    "node-opus" : "^0.2.1",
     "youtube-node" : "^4.2.0"
   },
   "author": "BDISTIN",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "discord.js" : "github:hydrabolt/discord.js#master",
 	"ytdl-core" :  "github:fent/node-ytdl-core#master",
-  "node-opus" : "^0.2.1"
+  "node-opus" : "^0.2.1",
+  "youtube-node" : "^4.2.0"
   },
   "author": "BDISTIN",
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "discord.js" : "github:hydrabolt/discord.js#master",
-	"ytdl-core" :  "github:fent/node-ytdl-core#master",
-  "node-opus" : "^0.2.1",
-  "youtube-node" : "^4.2.0"
+    "discord.js" : "11.0.0",
+    "ytdl-core" :  "github:fent/node-ytdl-core#master",
+    "node-opus" : "^0.2.1"
+    "youtube-node" : "^4.2.0"
   },
   "author": "BDISTIN",
   "license": "MIT"

--- a/tokens.json.example
+++ b/tokens.json.example
@@ -1,6 +1,7 @@
 {
     "d_token" : "YOUR DISCORD APP TOKEN",
-	"adminID" : "YOUR DISCORD USER ID",
+	  "adminID" : "YOUR DISCORD USER ID",
     "prefix" : "++",
-	"passes" : 1 //can be increased to reduce packetloss at the expense of upload bandwidth, 4-5 should be lossless at the expense of 4-5x upload
+    "yt_token" : "YOUR YOUTUBE API TOKEN",
+	  "passes" : 1 //can be increased to reduce packetloss at the expense of upload bandwidth, 4-5 should be lossless at the expense of 4-5x upload
 }


### PR DESCRIPTION
It's explained in the commits, but basically it uses youtube-node to get a song and add it to the queue by a query. youtube-node needs a YouTube API key, which this guide shows how to get:
http://help.dimsemenov.com/kb/wordpress-royalslider-tutorials/wp-how-to-get-youtube-api-key